### PR TITLE
30 feature only valid cards dragable

### DIFF
--- a/src/phasor/Deck.ts
+++ b/src/phasor/Deck.ts
@@ -1,5 +1,5 @@
 import Card from "./Card";
-import { NUM_CARDS, Suit } from "./constants/deck";
+import { NUM_CARDS, Suit, SUIT_COLOR } from "./constants/deck";
 import type { PileId } from "./constants/table";
 import { TABLEAU_PILES } from "./constants/table";
 
@@ -58,6 +58,28 @@ export default class Deck {
           curr.pile === card.pile && curr.position >= card.position
       )
       .sort((a: Card, b: Card) => a.position - b.position);
+  }
+
+  public validDraggableCard(card: Card): boolean {
+    const children: Card[] = this.cardChildren(card);
+
+    for (let i = 1; i < children.length; i++)
+    {
+      const current: Card = children[i];
+      const previous: Card = children[i-1];
+
+      if (current.value != previous.value - 1)
+      {
+        return false;
+      }
+
+      if (SUIT_COLOR[current.suit] === SUIT_COLOR[previous.suit])
+      {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   public topCard(pile: PileId): Card | null {

--- a/src/phasor/GameState.ts
+++ b/src/phasor/GameState.ts
@@ -72,6 +72,8 @@ export default class GameState extends Phaser.Scene {
         _pointer: Phaser.Input.Pointer,
         gameObject: Phaser.GameObjects.GameObject
       ) => {
+        this.dragChildren = [];
+
         if (gameObject instanceof Card && this.deck.validDraggableCard(gameObject)) {
           this.dragCardStart(gameObject);
         }

--- a/src/phasor/GameState.ts
+++ b/src/phasor/GameState.ts
@@ -72,7 +72,7 @@ export default class GameState extends Phaser.Scene {
         _pointer: Phaser.Input.Pointer,
         gameObject: Phaser.GameObjects.GameObject
       ) => {
-        if (gameObject instanceof Card) {
+        if (gameObject instanceof Card && this.deck.validDraggableCard(gameObject)) {
           this.dragCardStart(gameObject);
         }
       },


### PR DESCRIPTION
## Description
Please include a summary of the changes and the related issue. 
Prevented cards that were higher up in the stack from being dragable. Now only cards whos children meet the rules of decending rank and alternating suit can be drug.
Fixes #30 

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

