### PR TITLE
Added a method to determine the max number of moveable cards based on…

### DIFF
--- a/src/phasor/Deck.ts
+++ b/src/phasor/Deck.ts
@@ -60,8 +60,12 @@ export default class Deck {
       .sort((a: Card, b: Card) => a.position - b.position);
   }
 
-  public validDraggableCard(card: Card): boolean {
+  public validDraggableCard(card: Card, maxCards: number): boolean {
     const children: Card[] = this.cardChildren(card);
+
+    if (children.length > maxCards) {
+      return false;
+    }
 
     for (let i = 1; i < children.length; i++)
     {

--- a/src/phasor/GameState.ts
+++ b/src/phasor/GameState.ts
@@ -20,6 +20,8 @@ export default class GameState extends Phaser.Scene {
 
   private foundationPiles: Pile[] = [];
 
+  private cellPiles: Pile[] = [];
+
   private deck!: Deck;
 
   private scoreText!: Phaser.GameObjects.Text;
@@ -59,6 +61,10 @@ export default class GameState extends Phaser.Scene {
         this.foundationPiles.push(pile);
       }
 
+      else if (CELL_PILES.includes(pile.pileId)) {
+        this.cellPiles.push(pile);
+      }
+
     });
   }
 
@@ -72,7 +78,7 @@ export default class GameState extends Phaser.Scene {
       ) => {
         this.dragChildren = [];
 
-        if (gameObject instanceof Card && this.deck.validDraggableCard(gameObject)) {
+        if (gameObject instanceof Card && this.deck.validDraggableCard(gameObject, this.determineMaxCardsForMove())) {
           this.dragCardStart(gameObject);
         }
       },
@@ -322,6 +328,17 @@ export default class GameState extends Phaser.Scene {
       console.log("The card was dragged!");
     }
     this.isDragging = false;
+  }
+
+  public determineMaxCardsForMove(): number {
+    let maxCards: number = 1;
+    for (const cell of this.cellPiles) {
+      if (!this.deck.topCard(cell.pileId)) {
+        maxCards += 1;
+      }
+    }
+
+    return maxCards;
   }
 
   public update(): void {


### PR DESCRIPTION
… the number of empty freecells

## Description
The number of cards in a stack that you can move at any given time is now controlled by the number of open freecells you have

Fixes #36 

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

